### PR TITLE
Plan: README refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,117 @@
-# Alpine
+# Alpine Base Container
 
-FF: [Alpine Linux](https://alpinelinux.org) is an independent, non-commercial,
-general purpose Linux distribution designed for power users who appreciate
-security, simplicity and resource efficiency.
+> Upstream Alpine Linux distilled into a batteries-included base image for every downstream Eureka FARMS workload.
 
-This container is the base image that uses Alpine Linux as the initial
-image for other containers as such it's primary purpose is to provide
-functionality services for other downstream containers.
+## Overview
+| Item | Details |
+| --- | --- |
+| Owner | Adam Gautier / Blair Fontaine (planning) |
+| Purpose | Provide a hardened Alpine 3.22 base image with consistent backup, health, privilege, and entrypoint conventions for child containers. |
+| Registry | `gautada/alpine` (built via this repo’s `Containerfile`) |
+| Status | **Ready** — README plan branch: `plan/readme-refresh` |
+
+This repository seeds every other container image in the fleet. It standardizes:
+- Volume layout under `/mnt/volumes/{data,configmaps,backup,secrets}`
+- Default backup + health scaffolding that child images can override
+- s6-based init + privilege model so services come up the same way everywhere
+
+## Architecture
+```
++---------------------------+
+| Downstream container      |
+|  (inherits FROM this)     |
+|    Custom services        |
++-------------+-------------+
+              ^
+              |
++-------------+-------------+
+| gautada/alpine base image |
+|  • s6 init + entrypoint   |
+|  • Health proxy scripts   |
+|  • Backup + cron wiring   |
+|  • Privileged user group  |
++-------------+-------------+
+              ^
+              |
++-------------+-------------+
+| docker.io/library/alpine  |
++---------------------------+
+```
+- PlantUML source: [`architecture.puml`](./architecture.puml)
+- Init manager: `s6-svscan` (see `ENTRYPOINT` in `Containerfile`)
+- Health fan-out: `/usr/bin/container-{liveness,readiness,startup,test}` symlink to `container-health`
+
+## Branch & Release Model
+| Branch | Use |
+| --- | --- |
+| `dev` | Integration branch; all plan/README work merges here first. |
+| `main` | Mirror of released container definitions. |
+| `plan/*` | Short-lived planning/README efforts (current: `plan/readme-refresh`). |
+
+Create releases by merging tested changes into `main`, then tagging + pushing to the registry pipeline.
+
+## Local Setup
+1. **Clone & hydrate**
+   ```bash
+   git clone https://github.com/gautada/alpine.git
+   cd alpine
+   git fetch --all --prune
+   git checkout dev
+   ```
+2. **Prerequisites**
+   - Podman 5+ or Docker 24+
+   - `gh` CLI (for issues/PRs)
+   - Internet access to pull Alpine mirrors (mirror default: Princeton)
+
+## Build & Test
+| Task | Command |
+| --- | --- |
+| Build image | `podman build -t gautada/alpine:dev -f Containerfile .` |
+| Run shell | `podman run --rm -it gautada/alpine:dev /bin/zsh` |
+| Execute health proxy | `podman run --rm gautada/alpine:dev /usr/bin/container-health` |
+| Capture version | `podman run --rm gautada/alpine:dev /usr/bin/container-version` |
+
+Volumes `/mnt/volumes/{data,configmaps,backup,secrets}` are declared; mount host paths or Kubernetes PVCs there when testing child containers.
+
+## Customizing for Downstream Images
+### Backup contract
+- Default implementation lives in [`backup.sh`](./backup.sh) and simply logs + drops a timestamp into `data`.
+- Downstream images should provide `/etc/container/backup` with a real `container_backup()` function or mount a config map overriding the script.
+
+### Health checks
+- [`container-health.sh`](./container-health.sh) unifies startup, readiness, liveness, and `container-test` entrypoints.
+- To add bespoke checks, copy scripts into `/etc/container/health.d/*.health` or override `/etc/container/{liveness,readiness,startup}` in your derived image.
+
+### Privileges & users
+- [`privileges`](./privileges) is symlinked into `/etc/sudoers.d/privileges`.
+- Default user: `alpine` (`UID=1001`, member of `privileged` group). Change via build args `USER`, `UID`, `GID`.
+
+### Entry points & init
+- s6 watches `/etc/services.d/*/run`; add your service definitions there via the downstream `Containerfile`.
+- Custom entrypoints can replace `/usr/bin/s6-svscan` by overriding `ENTRYPOINT` in the child image if needed.
+
+## Operations Playbook
+| Scenario | Steps |
+| --- | --- |
+| **Run backup manually** | `podman run --rm gautada/alpine:dev /etc/container/backup` (override script before running). |
+| **Rotate timezone** | Update `/etc/timezone` (defaults to `America/New_York`) then relink `/etc/localtime`. |
+| **Add cron health checks** | Drop scripts under `/etc/container/health.d` (see commented `cron.health.sh` & `os-health.sh`). |
+| **Update Alpine mirror** | Edit the `sed` line in the `Containerfile` if the Princeton mirror ever lags. |
+
+## Planning Hooks & Open Work
+- **Plan branch:** `plan/readme-refresh` (holds README + notes updates).
+- **Open issues influencing docs:**
+  - #102 Entrypoint bug — document final behavior once patch lands.
+  - #95 Backup script improvements — README now emphasizes overriding the default.
+  - #77 Full machine proxy — downstream guidance will link here once design is approved.
+  - #43 Additional status scripts — reference `container-health` scaffolding.
+- Keep the `plan-readme` topic until PR merges; remove afterwards.
+
+## Contact
+| Role | Person |
+| --- | --- |
+| Product / Infra owner | Adam Gautier (@gautada) |
+| Planning / README upkeep | Blair Fontaine (@blairfontaine) |
+| Execution follow-up | Nyx Calder (@nyxcalder) |
+
+Need help? Drop a note in Slack or open an issue — include logs from `/usr/bin/container-health` when reporting runtime problems.

--- a/cohort/plan/notes.md
+++ b/cohort/plan/notes.md
@@ -1,0 +1,31 @@
+# README Planning Notes — 2026-02-27
+
+- **Planner:** Blair Fontaine
+- **Plan branch:** `plan/readme-refresh`
+- **Objective:** Apply the `plan-readme` protocol so this base image has a production-ready README + handoff assets.
+
+## Branch inventory
+| Branch | Status |
+| --- | --- |
+| `main` | Tracks released container definitions. Up to date with origin. |
+| `dev` | Active integration branch; README work will merge here first. |
+| `plan/readme-refresh` | Current planning branch for README upgrades. |
+
+## Issue audit (open items)
+| # | Title | Notes |
+| --- | --- | --- |
+| #102 | Entrypoint bug | Needs repro & fix plan; README should reference the entrypoint contract once resolved. |
+| #95 | Issue with backup script | Downstream users need clarity on overriding `container_backup`; document default behavior. |
+| #77 | Setup a full machine proxy | Future enhancement; call out in README planning hooks. |
+| #43 | Add the check scripts for status | Ties into health probes; surface current default + TODOs. |
+
+## README gaps identified
+1. Only two paragraphs existed — no setup, branch model, or health/backup guidance.
+2. No documentation for the bundled helper scripts (backup, health, version, privileges).
+3. Lacked deployment/testing instructions (Podman build, health checks, volume expectations).
+4. No link to open work or the planning branch.
+
+## Actions
+- Expand README to cover overview, architecture, environments, setup, operations, planning hooks, and contacts per protocol.
+- Reference the pending issues above so Adam can track README-driven follow-ups.
+- After README + notes committed, push branch, open PR to `dev`, assign Adam, and add project item in "Ready".


### PR DESCRIPTION
## Summary
- expand README with architecture, setup, operations, and planning hooks per plan-readme protocol
- add cohort/plan/notes.md capturing branch + issue audit

## Testing
- doc-only