### PR TITLE
fix: ensure container-entrypoint is executable

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -43,6 +43,7 @@ COPY backup.sh /etc/container/backup
 # │ ENTRYPOINT         │
 # ╰――――――――――――――――――――╯
 COPY container-entrypoint.sh /usr/bin/container-entrypoint
+RUN chmod +x /usr/bin/container-entrypoint
 COPY entrypoint.sh /etc/container/entrypoint
 
 # ╭――――――――――――――――――――╮


### PR DESCRIPTION
The error `crun: executable file /usr/bin/container-entrypoint not found in $PATH` often occurs when a file exists but lacks executable permissions, or when its interpreter (shebang) is missing/invalid.

I have added an explicit `chmod +x /usr/bin/container-entrypoint` to the `Containerfile` to ensure it can be invoked as an executable.

AC Status:
- [x] [Develop] Added chmod +x to container-entrypoint in Containerfile.
- [ ] [Integrate] Verification in CI.

Risk: Low